### PR TITLE
[Feat] 향수 이야기 전체조회/미리보기/상세조회 기능 추가

### DIFF
--- a/src/main/java/chic_chic/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/chic_chic/spring/apiPayload/code/status/ErrorStatus.java
@@ -22,8 +22,10 @@ public enum ErrorStatus implements BaseErrorCode {
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
 
     // 예시,,,
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
 
+    // 향수 이야기 관련 에러
+    PERFUME_STORY_NOT_FOUND(HttpStatus.NOT_FOUND, "STORY4001", "해당 향수 이야기를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/chic_chic/spring/config/SecurityConfig.java
+++ b/src/main/java/chic_chic/spring/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
                         "/swagger-ui.html",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
-                        "/swagger-resources/**"
+                        "/swagger-resources/**",
+                        "/perfume-stories/**"
                 ).permitAll()
                 .anyRequest().authenticated()
 

--- a/src/main/java/chic_chic/spring/domain/entity/PerfumeStory.java
+++ b/src/main/java/chic_chic/spring/domain/entity/PerfumeStory.java
@@ -1,0 +1,33 @@
+package chic_chic.spring.domain.entity;
+
+import chic_chic.spring.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "Perfume_Story")
+public class PerfumeStory extends BaseEntity {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long storyId;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String summary;
+
+    @Column(columnDefinition = "LONGTEXT")
+    private String content;
+
+    private String thumbnailUrl;
+
+    private String userId;  // 관리자 ID
+}

--- a/src/main/java/chic_chic/spring/domain/repository/PerfumeStoryRepository.java
+++ b/src/main/java/chic_chic/spring/domain/repository/PerfumeStoryRepository.java
@@ -1,0 +1,7 @@
+package chic_chic.spring.domain.repository;
+
+import chic_chic.spring.domain.entity.PerfumeStory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PerfumeStoryRepository extends JpaRepository<PerfumeStory, Long> {
+}

--- a/src/main/java/chic_chic/spring/web/controller/PerfumeStoryController.java
+++ b/src/main/java/chic_chic/spring/web/controller/PerfumeStoryController.java
@@ -1,0 +1,41 @@
+package chic_chic.spring.web.controller;
+
+import chic_chic.spring.apiPayload.ApiResponse;
+import chic_chic.spring.web.dto.PerfumeStoryDetailResponse;
+import chic_chic.spring.web.dto.PerfumeStoryResponse;
+import chic_chic.spring.web.service.PerfumeStoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/perfume-stories")
+public class PerfumeStoryController {
+
+    private final PerfumeStoryService perfumeStoryService;
+
+    // 목록 전체보기
+    @GetMapping
+    public ApiResponse<List<PerfumeStoryResponse>> getAllStories() {
+        List<PerfumeStoryResponse> result = perfumeStoryService.getAllStories();
+        return ApiResponse.onSuccess(result);
+    }
+
+    // 미리보기 카드
+    @GetMapping("/preview")
+    public ApiResponse<List<PerfumeStoryResponse>> getPreviewStories(
+            @RequestParam(defaultValue = "3") int size  // ?size=n 으로 개수 조절 가능
+    ) {
+        List<PerfumeStoryResponse> result = perfumeStoryService.getPreviewStories(size);
+        return ApiResponse.onSuccess(result);
+    }
+
+    // 글 상세보기 (전문 확인)
+    @GetMapping("/{id}")
+    public ApiResponse<PerfumeStoryDetailResponse> getStoryDetail(@PathVariable Long id) {
+        PerfumeStoryDetailResponse result = perfumeStoryService.getStoryDetail(id);
+        return ApiResponse.onSuccess(result);
+    }
+}

--- a/src/main/java/chic_chic/spring/web/dto/PerfumeStoryDetailResponse.java
+++ b/src/main/java/chic_chic/spring/web/dto/PerfumeStoryDetailResponse.java
@@ -1,0 +1,32 @@
+package chic_chic.spring.web.dto;
+
+
+import chic_chic.spring.domain.entity.PerfumeStory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+// 향수 이야기 상세 조회 (전체글)
+@Getter
+@Builder
+public class PerfumeStoryDetailResponse {
+
+    private Long storyId;
+    private String title;
+    private String summary;
+    private String content;
+    private String thumbnailUrl;
+    private LocalDateTime createdAt;
+
+    public static PerfumeStoryDetailResponse fromEntity(PerfumeStory story) {
+        return PerfumeStoryDetailResponse.builder()
+                .storyId(story.getStoryId())
+                .title(story.getTitle())
+                .summary(story.getSummary())
+                .content(story.getContent())
+                .thumbnailUrl(story.getThumbnailUrl())
+                .createdAt(story.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/chic_chic/spring/web/dto/PerfumeStoryResponse.java
+++ b/src/main/java/chic_chic/spring/web/dto/PerfumeStoryResponse.java
@@ -1,0 +1,24 @@
+package chic_chic.spring.web.dto;
+
+import chic_chic.spring.domain.entity.PerfumeStory;
+import lombok.Builder;
+import lombok.Getter;
+
+// 향수 이야기 (전체 조회)
+@Builder
+@Getter
+public class PerfumeStoryResponse {
+    private Long storyId;
+    private String title;
+    private String summary;
+    private String thumbnailUrl;
+
+    public static PerfumeStoryResponse fromEntity(PerfumeStory story) {
+        return PerfumeStoryResponse.builder()
+                .storyId(story.getStoryId())
+                .title(story.getTitle())
+                .summary(story.getSummary())
+                .thumbnailUrl(story.getThumbnailUrl())
+                .build();
+    }
+}

--- a/src/main/java/chic_chic/spring/web/service/PerfumeStoryService.java
+++ b/src/main/java/chic_chic/spring/web/service/PerfumeStoryService.java
@@ -1,0 +1,45 @@
+package chic_chic.spring.web.service;
+
+import chic_chic.spring.apiPayload.exception.GeneralException;
+import chic_chic.spring.domain.entity.PerfumeStory;
+import chic_chic.spring.domain.repository.PerfumeStoryRepository;
+import chic_chic.spring.web.dto.PerfumeStoryDetailResponse;
+import chic_chic.spring.web.dto.PerfumeStoryResponse;
+import chic_chic.spring.apiPayload.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PerfumeStoryService {
+
+    private final PerfumeStoryRepository perfumeStoryRepository;
+
+    // 전체 조회
+    public List<PerfumeStoryResponse> getAllStories() {
+        return perfumeStoryRepository.findAll().stream()
+                .map(PerfumeStoryResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 상세 조회
+    public PerfumeStoryDetailResponse getStoryDetail(Long id) {
+        PerfumeStory story = perfumeStoryRepository.findById(id)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PERFUME_STORY_NOT_FOUND));
+        return PerfumeStoryDetailResponse.fromEntity(story);
+    }
+
+    // 갯수 설정하여 미리보기 가져오기
+    public List<PerfumeStoryResponse> getPreviewStories(int size) {
+        Pageable pageable = PageRequest.of(0, size, Sort.by("createdAt").descending());
+        return perfumeStoryRepository.findAll(pageable).stream()
+                .map(PerfumeStoryResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### 💡 작업 개요
- 향수 이야기 기능: 전체 조회, 미리보기 조회, 상세 조회 기능 구현
- 공통 응답 포맷(ApiResponse), 예외 처리 구조(GeneralException) 연동

### ✅ 작업 내용
- [x] 기능 개발  
  - 전체 조회 API (`GET /perfume-stories`)
  - 미리보기 API (`GET /perfume-stories/preview?size=n`)
  - 상세 조회 API (`GET /perfume-stories/{id}`)
- [x] 예외 처리
  - 존재하지 않는 향수 이야기 조회 시 `PERFUME_STORY_NOT_FOUND` 에러 반환
- [x] Swagger 연동 확인
- [x] Security 설정에서 해당 URI 모두 `permitAll()` 적용
- [ ] 리팩토링 / 정리 (다음 단계에서 필요시 진행 예정)

### 🧪 테스트 내용
- Postman으로 각 API 정상 응답 확인
  - 전체 조회 시 전체 리스트 반환
  - `/preview?size=3` → 3개만 출력되는 것 확인
  - `/perfume-stories/{id}` 요청 시 상세 내용 출력 정상
- 존재하지 않는 ID 요청 시 404 에러 및 예외 메시지 정상 출력

### 📝 기타 참고 사항
- UI 기준으로 썸네일/제목/요약 텍스트 기준의 리스트 응답 구현됨
- ERD 기반 테이블 설계 후 더미 데이터 삽입하여 테스트 완료
- 추후 기능 추가 시 해당 서비스 및 컨트롤러 기반 확장 예정
